### PR TITLE
VLC player version 3.0.21 (other don't check) don't support float vol…

### DIFF
--- a/listen-vlc.el
+++ b/listen-vlc.el
@@ -134,7 +134,7 @@ VOLUME is an integer percentage."
         (progn
           (unless (<= 0 volume max-volume)
             (error "VOLUME must be 0-%s" max-volume))
-          (listen--send player (format "volume %s" (* 255 (/ volume 100.0)))))
+          (listen--send player (format "volume %i" (* 255 (/ volume 100.0)))))
       (* 100 (/ (string-to-number (listen--send player "volume")) 255.0)))))
 
 (provide 'listen-vlc)


### PR DESCRIPTION
VLC player version 3.0.21 (other don't check) don't support float volume control.

```
VLC media player 3.0.21 Vetinari
Command Line Interface initialized. Type `help' for help.
> volume 1.5
Error in `volume 1.5' lua/modules/common.lua:207: bad argument #1 to 'set' (number has no integer representation)
```

Changed vlc volume format from %s to %i.
I can't imagine any case, that who control volume more precision that integer.
