### PR TITLE
Use official comment size limit for vorbis tags

### DIFF
--- a/README.org
+++ b/README.org
@@ -202,6 +202,9 @@ The ~listen-mode~ minor mode runs a timer which plays the next track in the curr
 
 *Fixes*
 - Race condition in MPV support.  (Fixes [[https://github.com/alphapapa/listen.el/issues/40][#40]].  Thanks to [[https://github.com/SemyonSinchenko][Semyon Sinchenko]] and [[https://github.com/Sjmarf][Sjmarf]] for reporting.)
+
+*Compatibility*
+- Accept Vorbis comments up to 16 MB in size.  (See [[https://github.com/alphapapa/listen.el/pull/34][#34]].  Thanks to [[https://github.com/Etenil][@Etenil]] for reporting, and [[https://github.com/MinallW][Miguel Ángel Suárez Calles]] for testing.)
 ** v0.10
 
 *Additions*

--- a/README.org
+++ b/README.org
@@ -198,6 +198,9 @@ The ~listen-mode~ minor mode runs a timer which plays the next track in the curr
 - Similarly, you might even see an icon in your task switcher indicating that Emacs is playing sound (e.g. with KDE Plasma).
 * Changelog
 
+** v0.10.1-pre
+
+Nothing new yet.
 ** v0.10
 
 *Additions*

--- a/README.org
+++ b/README.org
@@ -200,7 +200,8 @@ The ~listen-mode~ minor mode runs a timer which plays the next track in the curr
 
 ** v0.10.1-pre
 
-Nothing new yet.
+*Fixes*
+- Race condition in MPV support.  (Fixes [[https://github.com/alphapapa/listen.el/issues/40][#40]].  Thanks to [[https://github.com/SemyonSinchenko][Semyon Sinchenko]] and [[https://github.com/Sjmarf][Sjmarf]] for reporting.)
 ** v0.10
 
 *Additions*

--- a/docs/README.org
+++ b/docs/README.org
@@ -237,7 +237,8 @@ The ~listen-mode~ minor mode runs a timer which plays the next track in the curr
 
 ** v0.10.1-pre
 
-Nothing new yet.
+*Fixes*
++ Race condition in MPV support.  (Fixes [[https://github.com/alphapapa/listen.el/issues/40][#40]].  Thanks to [[https://github.com/SemyonSinchenko][Semyon Sinchenko]] and [[https://github.com/Sjmarf][Sjmarf]] for reporting.)
 
 ** v0.10
 

--- a/docs/README.org
+++ b/docs/README.org
@@ -240,6 +240,9 @@ The ~listen-mode~ minor mode runs a timer which plays the next track in the curr
 *Fixes*
 + Race condition in MPV support.  (Fixes [[https://github.com/alphapapa/listen.el/issues/40][#40]].  Thanks to [[https://github.com/SemyonSinchenko][Semyon Sinchenko]] and [[https://github.com/Sjmarf][Sjmarf]] for reporting.)
 
+*Compatibility*
++ Accept Vorbis comments up to 16 MB in size.  (See [[https://github.com/alphapapa/listen.el/pull/34][#34]].  Thanks to [[https://github.com/Etenil][@Etenil]] for reporting, and [[https://github.com/MinallW][Miguel Ángel Suárez Calles]] for testing.)
+
 ** v0.10
 
 *Additions*

--- a/docs/README.org
+++ b/docs/README.org
@@ -235,6 +235,10 @@ The ~listen-mode~ minor mode runs a timer which plays the next track in the curr
   
 * Changelog
 
+** v0.10.1-pre
+
+Nothing new yet.
+
 ** v0.10
 
 *Additions*

--- a/listen-info.el
+++ b/listen-info.el
@@ -92,7 +92,7 @@ exhaustion in case of garbled or malicious inputs.
 This limit is used with Opus and FLAC streams as well, since
 their comments have almost the same format as Vorbis.")
 
-(defconst listen-info--max-vorbis-comment-size (* 64 1024)
+(defconst listen-info--max-vorbis-comment-size (expt 2 32)
   "Maximum length for a single Vorbis comment field.
 Technically a single Vorbis comment may have a length up to 2^32
 bytes, but in practice processing must be constrained to prevent

--- a/listen-info.el
+++ b/listen-info.el
@@ -95,11 +95,11 @@ their comments have almost the same format as Vorbis.")
 (defconst listen-info--max-vorbis-comment-size (expt 2 32)
   "Maximum length for a single Vorbis comment field.
 Technically a single Vorbis comment may have a length up to 2^32
-bytes, but in practice processing must be constrained to prevent
-memory exhaustion in case of garbled or malicious inputs.
+bytes.
 
-This limit is used with Opus and FLAC streams as well, since
-their comments have almost the same format as Vorbis.")
+Ideally this should be limited, but some tag editors have been
+known to stuff base64-encoded images into comments, while still
+honoring the vorbis spec of keeping them < 2^32 bytes.")
 
 (defconst listen-info--max-vorbis-vendor-length 1024
   "Maximum length of Vorbis vendor string.

--- a/listen-info.el
+++ b/listen-info.el
@@ -92,14 +92,14 @@ exhaustion in case of garbled or malicious inputs.
 This limit is used with Opus and FLAC streams as well, since
 their comments have almost the same format as Vorbis.")
 
-(defconst listen-info--max-vorbis-comment-size (expt 2 32)
+(defconst listen-info--max-vorbis-comment-size (* 16 1024 1024)
   "Maximum length for a single Vorbis comment field.
-Technically a single Vorbis comment may have a length up to 2^32
-bytes.
-
-Ideally this should be limited, but some tag editors have been
-known to stuff base64-encoded images into comments, while still
-honoring the vorbis spec of keeping them < 2^32 bytes.")
+Technically a single Vorbis comment may have a length up to 2^32 bytes,
+but it doesn't seem wise to accept 4 GB in this field, which could
+easily exhaust memory.  Some tag editors may use more than 16 kB in this
+field (e.g. base64-encoded images), so we will allow 16 MB by default.
+Users who need comments larger than that should probably edit this value
+in their config.")
 
 (defconst listen-info--max-vorbis-vendor-length 1024
   "Maximum length of Vorbis vendor string.

--- a/listen-mpv.el
+++ b/listen-mpv.el
@@ -230,7 +230,11 @@ Stops playing, clears playlist, adds FILE, and plays it."
       (setf (map-elt (listen-player-etc player) :elapsed)
             (+ (time-to-seconds
                 (time-subtract (current-time) (listen-player-playback-started-at player)))
-               (listen-player-playback-started-from player)))
+               (or (listen-player-playback-started-from player)
+                   ;; Avoid race condition: the playback-started-from slot is nil, so assume it
+                   ;; should be 0 but hasn't been set yet (if it turns out to be incorrect, it will
+                   ;; only cause the value returned by this function to be briefly incorrect).
+                   0)))
     (map-elt (listen-player-etc player) :elapsed)))
 
 (cl-defmethod listen--length ((player listen-player-mpv))

--- a/listen.el
+++ b/listen.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Adam Porter <adam@alphapapa.net>
 ;; Keywords: multimedia
 ;; Package-Requires: ((emacs "29.1") (persist "0.6") (taxy "0.10") (taxy-magit-section "0.13") (transient "0.5.3"))
-;; Version: 0.10
+;; Version: 0.10.1-pre
 ;; URL: https://github.com/alphapapa/listen.el
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
The official vorbis size for comments is 2^32 bytes, and sadly I happen to have some files that make use of more than 64kB of comment space (somehow the tag editor stuffed a base64-encoded image in there).

An argument could be made that instead of expanding the maximum comment size, we could instead print a warning and create an empty comment; I can look into doing that if it's seen as more elegant.

Another point could be that those files should be edited; but technically speaking they do comply with the vorbis spec and I don't think listen.el should require users to know how to edit vorbis tags to listen to their music :-/.

Let me know if there's anything I should change.