### PR TITLE
Start queue at 1 rather than 0

### DIFF
--- a/listen-queue.el
+++ b/listen-queue.el
@@ -168,7 +168,7 @@ Useful for when `save-excursion' does not preserve point."
                            " ")))
                  (list :name "#" :primary 'descend
                        :getter (lambda (track _table)
-                                 (cl-position track (listen-queue-tracks queue))))
+                                 (+ 1 (cl-position track (listen-queue-tracks queue)))))
                  (list :name "Duration"
                        :getter (lambda (track _table)
                                  (when-let ((duration (listen-track-duration track)))


### PR DESCRIPTION
Currently, the listen queue starts at 0, this small adjustment will make the queue start at 1, rather than zero. This seems more intuitive to me to have the first track be track 1, rather than track 0.